### PR TITLE
Fix output wire selection in circuit evaluation

### DIFF
--- a/src/circuit/circuit.py
+++ b/src/circuit/circuit.py
@@ -1444,9 +1444,7 @@ class circuit:
                 wire[g.index] = g.operation.function(*[wire[ig.index] for ig in g.inputs])
 
         return self.signature.output(
-            wire[
-                -self.count(lambda g: len(g.outputs) == 0 and g.is_output):
-            ]
+            [wire[g.index] for g in self.gates if len(g.outputs) == 0 and g.is_output]
         )
 
     def to_logical(self: circuit) -> logical.logical:


### PR DESCRIPTION
This PR fixes a bug, namely that `circuit.evaluate` assumes the output gates are the last wires: https://github.com/reity/circuit/blob/497e6e81849f5c661ef6b530538a056dff40ac4d/src/circuit/circuit.py#L1448

This may not necessarily be the case, unless you call `circuit.prune_and_topological_sort_stable`. Here's an example:
```python
from circuit import *

c = circuit()
in0 = c.gate(op.id_, is_input=True)
in1 = c.gate(op.id_, is_input=True)
and_gate = c.gate(op.and_, [in0, in1])
c.gate(op.id_, [and_gate], is_output=True)
xor_gate = c.gate(op.xor_, [in0, in1])

assert c.evaluate([0, 1]) == [1]
c.prune_and_topological_sort_stable()
assert c.evaluate([0, 1]) == [0]

```